### PR TITLE
Release 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,18 @@ self.client.test(message="This is a test message!")
 
 ### List method
 
-```
-```
+List downloaded files or files able to be downloaded, with the capacity of filter it by:
+- >= start_date
+- <= end_date
+- status in ["DISPONIBLE", "DESCARGADO"]
 
+```
+STATUS = "DISPONIBLE"
+date_start = 
+date_end = 
+
+self.client.list(status=STATUS, date_start=date_start, date_end=date_end)
+```
 
 ### Fetch method
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ client = Client(**oauth_config)
 - [Fetch](#fetch-method)
 - [Download](#download-method)
 
+
 ### Test method
+Method desired to test the connection with the API using the `echoseguro` resource.
 
 ```
-
+self.client.test(message="This is a test message!")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,49 @@ Simply configure the KEY and the SECRET as exported environment vars, or attach 
 ### ENV vars
 
 ```
-export CNMC_CONSUMER_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx
-export CNMC_CONSUMER_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxx
+$ export CNMC_CONSUMER_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx
+$ export CNMC_CONSUMER_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxx
+
 ```
 
 ### Passed config
 
+```
 oauth_config = {
     'key': "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx",
     'secret': "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx",
 }
 
+client = Client(**oauth_config)
+```
+
+## Available methods
+
+- [Test](#test-method)
+- [List](#list-method)
+- [Fetch](#fetch-method)
+- [Download](#download-method)
+
+### Test method
+
+```
+
+```
+
+
+### List method
+
+```
+```
+
+
+### Fetch method
+
+```
+```
+
+
+### Download method
+
+```
+```

--- a/README.md
+++ b/README.md
@@ -8,15 +8,26 @@ Simply configure the KEY and the SECRET as exported environment vars, or attach 
 
 ### ENV vars
 
+Just define the needed ENV vars:
 ```
 $ export CNMC_CONSUMER_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx
 $ export CNMC_CONSUMER_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxx
 
 ```
 
-### Passed config
+, and instantiate the Client without any parameter:
 
 ```
+from cnmc import Client
+client = Client()
+``` 
+
+### Passed config
+
+Instantiate the Client passing the key and secret oauth tokens:
+```
+from cnmc import Client
+
 oauth_config = {
     'key': "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx",
     'secret': "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # CNCM client
 
 It provides a Python client desired to interact with the CNMC API.
+
+## Usage
+
+Simply configure the KEY and the SECRET as exported environment vars, or attach it at Client initialization time
+
+### ENV vars
+
+```
+export CNMC_CONSUMER_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx
+export CNMC_CONSUMER_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxx
+```
+
+### Passed config
+
+oauth_config = {
+    'key': "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx",
+    'secret': "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxxxxx",
+}
+

--- a/README.md
+++ b/README.md
@@ -47,7 +47,19 @@ client = Client(**oauth_config)
 
 ### Fetch method
 
+Define the list of CUPS to analyze and the desired file type.
+
+List of types:
+- SIPS2_PS_ELECTRICIDAD
+- SIPS2_CONSUMOS_ELECTRICIDAD
+- SIPS2_PS_GAS
+- SIPS2_CONSUMOS_GAS
+
 ```
+the_cups = [ "CUPSA", "CUPSB" ]
+the_type = "SIPS2_PS_ELECTRICIDAD"
+
+self.client.fetch(cups=the_cups, file_type=the_type)
 ```
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,11 @@
 # 0.1.0
 - Initial CNMC client
+  - The client
+    - List files method
+    - Fetch files method
+    - Download file method //WIP
+  - The CNMC API
+    - OAuth1 session establishment
+    - GET and POST HTTP actions
+  - Basic Mamba specs for all functionalities
+  

--- a/changelog.md
+++ b/changelog.md
@@ -8,4 +8,6 @@
     - OAuth1 session establishment
     - GET and POST HTTP actions
   - Basic Mamba specs for all functionalities
-  
+  - New requirements
+    - Marshmallow
+    - Munch

--- a/cnmc/__init__.py
+++ b/cnmc/__init__.py
@@ -6,3 +6,4 @@ __author__ = 'XaviTorello'
 __version__ = '0.1.0'
 
 from .client import Client
+from .cnmc import CNMC_API

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -48,4 +48,9 @@ class Client(object):
         if date_end:
             params['fechaHasta'] = date_start
 
-        return self.API.post(resource="/consultar", params=params)
+        response = self.API.post(resource="/consultar", params=params)
+
+        schema = ListSchema()
+        result = schema.load(response)
+        return result.data
+    

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -38,7 +38,7 @@ class Client(object):
         """
         params = {
             "idProcedimiento": "2",
-            "nifEmpresa": "XXXXXXX",
+            "nifEmpresa": self.API.NIF,
             "estado": status,
         }
 

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -82,6 +82,8 @@ class Client(object):
         - SIPS2_CONSUMOS_GAS
 
         See https://documentacion.cnmc.es/doc/display/ICSV/API+de+consulta+individualizada
+
+        Alternative, disabled right now: https://documentacion.cnmc.es/doc/display/ICSV/API+de+consulta+individualizada 
         """
 
         assert type(cups) in [list]

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -59,7 +59,7 @@ class Client(object):
             params['fechaHasta'] = date_start
 
         # Ask the API 
-        response = self.API.post(resource="/consultar", params=params)
+        response = self.API.post(resource="/ficheros/v1/consultar", params=params)
 
         # Validate and deserialize the response 
         schema = ListSchema()
@@ -69,3 +69,28 @@ class Client(object):
             return result.data
         else:
             raise ValueError('Result deserialization is not performed properly for "{}"'.format(repr(result)))
+
+
+    def fetch(self, cups, file_type):
+        """
+        Fetch partial data for a list of CUPS
+        
+        Available file types:
+        - SIPS2_PS_ELECTRICIDAD
+        - SIPS2_CONSUMOS_ELECTRICIDAD
+        - SIPS2_PS_GAS
+        - SIPS2_CONSUMOS_GAS
+
+        See https://documentacion.cnmc.es/doc/display/ICSV/API+de+consulta+individualizada
+        """
+
+        assert type(cups) in [list]
+        assert file_type in ["SIPS2_PS_ELECTRICIDAD", "SIPS2_CONSUMOS_ELECTRICIDAD", "SIPS2_PS_GAS", "SIPS2_CONSUMOS_GAS"]
+
+        params = {
+            "cups": ",".join(cups)
+        }
+
+        # Ask the API 
+        response = self.API.get(resource="/verticales/v1/SIPS/consulta/v1/{}.csv".format(file_type), params=params)
+        return response

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -3,7 +3,43 @@
 import oauth2 as oauth
 import logging
 
+CNCM_envs = {
+    'prod': '',
+    'staging': '',
+}
+
 class Client(object):
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         logging.info("Initializing CNCM Client")
+
+        # Handle environment, df "prod"
+        self.environment = "prod"
+        if 'environment' in kwargs:
+            assert type(kwargs['environment']) == str, "environment argument must be an string"
+            assert kwargs['environment'] in CNCM_envs.keys(), "Provided environment '{}' not recognized in defined CNMC_envs {}".format(kwargs['environment'], str(FACE_ENVS.keys()))
+            self.environment = kwargs['environment']
+
+        self.consumer = oauth.Consumer(key="your-twitter-consumer-key", secret="your-twitter-consumer-secret")
+
+        self.client = oauth.Client(self.consumer)
+
+
+
+    def method(self, method, resource, **kwargs):
+        """
+        Main method handler
+
+        So far, ask the API and return a JSON representation of the response
+        """
+        response, content = self.client.request(resource, method, **kwargs)
+        print (response)
+        return response
+        return result.json()
+
+
+    def get(self, resource, **kwargs):
+        """
+        GET method, it trigger an API.get method consuming the desired resource
+        """
+        return self.method(method="get", resource=resource, **kwargs)

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -48,7 +48,6 @@ class Client(object):
             raise ValueError('Result deserialization is not performed properly for "{}"'.format(repr(result)))
 
 
-
     def list(self, status=None, date_start=None, date_end=None):
         """
         List downloaded files or files able to be downloaded, with the capacity of filter it by:
@@ -116,3 +115,19 @@ class Client(object):
         # Ask the API 
         response = self.API.get(resource="/verticales/v1/SIPS/consulta/v1/{}.csv".format(file_type), params=params)
         return response
+
+
+    def download(self, filename):
+        """
+        Download 
+
+        See https://documentacion.cnmc.es/doc/display/ICSV/API+de+consulta+individualizada
+
+        Alternative, disabled right now: https://documentacion.cnmc.es/doc/display/ICSV/API+de+consulta+individualizada 
+        """
+
+        assert type(filename) == str
+
+        # Ask the API 
+        response = self.API.get(resource="/ficheros/v1/descarga/{}".format(filename))
+        return response    

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .cnmc import CNMC_API
-from .models import ListSchema
+from .models import ListSchema, TestSchema
 import os
 
 AVAILABLE_FILE_STATES = ["DISPONIBLE", "DESCARGADO"]
@@ -27,6 +27,26 @@ class Client(object):
             self.environment = environment
 
         self.API = CNMC_API(key=self.key, secret=self.secret, environment=self.environment)
+
+
+    def test(self, message):
+        """
+        Test do not follow the default method
+        """
+        params = {
+            "m": message,
+        }
+        response = self.API.get(resource="/test/v1/echoseguro", params=params)
+
+        # Validate and deserialize the response 
+        schema = TestSchema()
+        result = schema.load(response)
+
+        if not result.errors:
+            return result.data
+        else:
+            raise ValueError('Result deserialization is not performed properly for "{}"'.format(repr(result)))
+
 
 
     def list(self, status=None, date_start=None, date_end=None):

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from .cnmc import CNMC_API
+from .models import ListSchema
 import os
 
 class Client(object):

--- a/cnmc/client.py
+++ b/cnmc/client.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import oauth2 as oauth
+from authlib.client import OAuth1Session
+import os
 import logging
+            
 
 CNCM_envs = {
     'prod': '',
@@ -13,6 +15,26 @@ class Client(object):
     def __init__(self, **kwargs):
         logging.info("Initializing CNCM Client")
 
+        # Handle the key and the secret
+        self.key = None
+        if 'key' in kwargs:
+            assert type(kwargs['key']) == str, "The key must be an string. Current type '{}'".format(type(kwargs['key']))
+            self.key = kwargs['key']
+        else:
+            self.key = os.getenv('CNMC_CONSUMER_KEY')
+        assert self.key, "The key is needed to initialize the CNCM connection"
+
+
+        # Handle the key and the secret
+        self.secret = None
+        if 'secret' in kwargs:
+            assert type(kwargs['secret']) == str, "The secret must be an string. Current type '{}'".format(type(kwargs['secret']))
+            self.key = kwargs['secret']
+        else:
+            self.secret = os.getenv('CNMC_CONSUMER_SECRET')
+        assert self.secret, "The secret is needed to initialize the CNCM connection"
+
+
         # Handle environment, df "prod"
         self.environment = "prod"
         if 'environment' in kwargs:
@@ -20,10 +42,7 @@ class Client(object):
             assert kwargs['environment'] in CNCM_envs.keys(), "Provided environment '{}' not recognized in defined CNMC_envs {}".format(kwargs['environment'], str(FACE_ENVS.keys()))
             self.environment = kwargs['environment']
 
-        self.consumer = oauth.Consumer(key="your-twitter-consumer-key", secret="your-twitter-consumer-secret")
-
-        self.client = oauth.Client(self.consumer)
-
+        self.session = OAuth1Session(self.key, self.secret)
 
 
     def method(self, method, resource, **kwargs):

--- a/cnmc/cnmc.py
+++ b/cnmc/cnmc.py
@@ -87,13 +87,3 @@ class CNMC_API(object):
         POST method, it dispatch a session.get method consuming the desired resource
         """
         return self.method(method="POST", resource=resource, **kwargs)
-
-
-    def test(self, message):
-        """
-        Test do not follow the default method
-        """
-        params = {
-            "m": message,
-        }
-        return self.session.request(method="GET", url="https://api.cnmc.gob.es/test/v1/echoseguro", params=params)

--- a/cnmc/cnmc.py
+++ b/cnmc/cnmc.py
@@ -60,16 +60,18 @@ class CNMC_API(object):
         url = self.url + resource
         response = self.session.request(method=method, url=url, **kwargs)
 
-        if response.status_code not in [404, 500, 403]:
+        # Handle errors        
+        if response.status_code >= 400:
             return {
                 'code': response.status_code,
-                'result': response.json(),
-                'error': False,
+                'error': True,
+                'message': str(response),
             }
         else:
             return {
                 'code': response.status_code,
-                'error': True,
+                'result': response.json(),
+                'error': False,
             }
 
 

--- a/cnmc/cnmc.py
+++ b/cnmc/cnmc.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+from authlib.client import OAuth1Session
+import logging
+from authlib.common.urls import add_params_to_uri       
+
+CNCM_envs = {
+    'prod': 'https://api.cnmc.gob.es/ficheros/v1',
+    'staging': '',
+}
+
+class CNMC_API(object):
+
+    def __init__(self, key=None, secret=None, environment=None, **kwargs):
+        logging.info("Initializing CNCM Client")
+
+        # Handle the key
+        if not key:
+            assert 'key' in kwargs
+            key = kwargs['key']
+        assert type(key) == str, "The key must be an string. Current type '{}'".format(type(key))
+        self.key = key
+
+        # Handle the secret
+        if not secret:
+            assert 'secret' in kwargs
+            secret = kwargs['secret']
+        assert type(secret) == str, "The key must be an string. Current type '{}'".format(type(secret))
+        self.secret = secret
+
+        # Handle environment, default value "prod"
+        self.environment = "prod"
+        if not environment:
+            if 'environment' in kwargs:
+                assert type(kwargs['environment']) == str, "environment argument must be an string"
+                assert kwargs['environment'] in CNCM_envs.keys(), "Provided environment '{}' not recognized in defined CNMC_envs {}".format(kwargs['environment'], str(FACE_ENVS.keys()))
+                self.environment = kwargs['environment']
+
+        self.url = CNCM_envs[self.environment]
+
+        self.session = OAuth1Session(self.key, self.secret, signature_method="HMAC-SHA1", signature_type="HEADER")
+        print (self.session)
+
+
+    def set_request_token (self):
+        """
+        Set the request token for current session
+        """
+        self.request_token = self.session.fetch_request_token(self.url)
+
+
+    def method(self, method, resource, **kwargs):
+        """
+        Main method handler
+
+        Fetch the requested URL with the requested action through the OAuth session and return a JSON representeation of the response with the resultant code
+        """
+        url = self.url + resource
+        response = self.session.request(method=method, url=url, **kwargs)
+
+        if response.status_code not in [404, 500, 403]:
+            return {
+                'code': response.status_code,
+                'result': response.json(),
+                'error': False,
+            }
+        else:
+            return {
+                'code': response.status_code,
+                'error': True,
+            }
+
+
+    def get(self, resource, **kwargs):
+        """
+        GET method, it dispatch a session.get method consuming the desired resource
+        """
+        return self.method(method="GET", resource=resource, **kwargs)
+
+
+    def post(self, resource, **kwargs):
+        """
+        POST method, it dispatch a session.get method consuming the desired resource
+        """
+        return self.method(method="POST", resource=resource, **kwargs)
+
+
+    def test(self, message):
+        """
+        Test do not follow the default method
+        """
+        params = {
+            "m": message,
+        }
+        return self.session.request(method="GET", url="https://api.cnmc.gob.es/test/v1/echoseguro", params=params)

--- a/cnmc/cnmc.py
+++ b/cnmc/cnmc.py
@@ -39,10 +39,21 @@ class CNMC_API(object):
         self.url = CNCM_envs[self.environment]
 
         self.session = OAuth1Session(self.key, self.secret, signature_method="HMAC-SHA1", signature_type="HEADER")
+        self.NIF = self.get_NIF()
 
-    @property
-    def NIF(self):
-        return "XXXXX"
+
+    def get_NIF(self):
+        """
+        Get NIF from test API method
+
+        It also support us to identify if session is established properly //as done by the oficial CNMC web client
+        """
+        response = self.get(resource="/test/v1/nif")
+        assert response['code'] == 200, "Connection is not established properly '{}'. Review oauth configuraion".format(str(response))
+        
+        assert 'result' in response and  'empresa' in response['result'] and response['result']['empresa'][0]
+        return response['result']['empresa'][0]
+
 
     def set_request_token (self):
         """

--- a/cnmc/cnmc.py
+++ b/cnmc/cnmc.py
@@ -39,8 +39,10 @@ class CNMC_API(object):
         self.url = CNCM_envs[self.environment]
 
         self.session = OAuth1Session(self.key, self.secret, signature_method="HMAC-SHA1", signature_type="HEADER")
-        print (self.session)
 
+    @property
+    def NIF(self):
+        return "XXXXX"
 
     def set_request_token (self):
         """

--- a/cnmc/cnmc.py
+++ b/cnmc/cnmc.py
@@ -5,8 +5,8 @@ import logging
 from authlib.common.urls import add_params_to_uri       
 
 CNCM_envs = {
-    'prod': 'https://api.cnmc.gob.es/ficheros/v1',
-    'staging': '',
+    'prod': 'https://api.cnmc.gob.es',
+    'staging': 'https://apipre.cnmc.gob.es',
 }
 
 class CNMC_API(object):

--- a/cnmc/models.py
+++ b/cnmc/models.py
@@ -1,0 +1,47 @@
+from marshmallow import Schema, fields, post_load
+from munch import Munch
+
+class CNMC_Response(Munch):
+    pass
+
+class ResponseSchema(Schema):
+    code = fields.Integer()
+    result = fields.Dict()
+    error = fields.Bool()
+
+    @post_load
+    def create_model(self, data):
+        return CNMC_Response(**data)
+
+
+
+class CNMC_ListEntry(Munch):
+    pass
+
+class ListEntrySchema(Schema):
+    uuid = fields.Str()
+    idProcedimiento = fields.Integer()
+    nifEmpresa = fields.Str()
+    numeroBytes = fields.Integer()
+    tipoFichero = fields.Str()
+    estado = fields.Str()
+    mime = fields.Str()
+    nombre = fields.Str()
+    hash = fields.Str()
+    fechaDisponibilidad = fields.Str()
+
+    @post_load
+    def create_model(self, data):
+        return CNMC_ListEntry(**data)
+
+
+
+class CNMC_List(Munch):
+    pass
+
+class ListSchema(ResponseSchema):
+    result = fields.Nested(ListEntrySchema, many=True)
+
+    @post_load
+    def create_model(self, data):
+        return CNMC_List(**data)

--- a/cnmc/models.py
+++ b/cnmc/models.py
@@ -1,6 +1,9 @@
 from marshmallow import Schema, fields, post_load
 from munch import Munch
 
+
+## Base response Models and Schemas
+
 class CNMC_Response(Munch):
     pass
 
@@ -14,6 +17,34 @@ class ResponseSchema(Schema):
         return CNMC_Response(**data)
 
 
+
+## CNMC Test resource Models and Schemas
+
+class CNMC_TestEntry(Munch):
+    pass
+
+class TestEntrySchema(Schema):
+    mensaje = fields.Str()
+    
+    @post_load
+    def create_model(self, data):
+        return CNMC_TestEntry(**data)
+
+
+class CNMC_Test(Munch):
+    pass
+
+class TestSchema(Schema):
+    result = fields.Nested(TestEntrySchema, many=False)
+
+    @post_load
+    def create_model(self, data):
+        return CNMC_Test(**data)
+
+
+
+
+## CNMC List resource Models and Schemas
 
 class CNMC_ListEntry(Munch):
     pass

--- a/cnmc/models.py
+++ b/cnmc/models.py
@@ -29,6 +29,9 @@ class ListEntrySchema(Schema):
     nombre = fields.Str()
     hash = fields.Str()
     fechaDisponibilidad = fields.Str()
+    fechaCaducidad = fields.Str()
+    uriDescargas = fields.Str()
+    descripción = fields.Str()
 
     @post_load
     def create_model(self, data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-oauth2
+Authlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Authlib
 Marshmallow
+Munch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Authlib
+Marshmallow

--- a/specs/client_spec.py
+++ b/specs/client_spec.py
@@ -10,7 +10,7 @@ from cnmc import Client
 fixtures_path = 'specs/fixtures/cnmc/'
 
 spec_VCR = vcr.VCR(
-    record_mode='all',
+    record_mode='new',
     cassette_library_dir=fixtures_path
 )
 
@@ -33,8 +33,15 @@ with description('A new'):
         with context('initialization'):
             with it('must be performed as expected'):
                 with spec_VCR.use_cassette('init.yaml'):
-                    response = self.client.list()
-                    print (response)
+                    assert self.client
 
-                    for element in response['result']:
-                        print (element.keys())
+        with context('list of pending files'):
+            with it('must be performed as expected'):
+                with spec_VCR.use_cassette('list.yaml'):
+                    response = self.client.list()
+                    
+                    assert response
+
+                    print (response)
+                    for element in response.result:
+                        print (element.nombre, element.estado, element.tipoFichero, element.uriDescargas)

--- a/specs/client_spec.py
+++ b/specs/client_spec.py
@@ -38,6 +38,18 @@ with description('A new'):
                 with spec_VCR.use_cassette('init.yaml'):
                     assert self.client
 
+
+        with context('test method'):
+            with it('must work as expected'):
+                with spec_VCR.use_cassette('test.yaml'):
+                    message="this is just a test!"
+                    response = self.client.test(message=message)
+                    
+                    assert response and 'result' in response
+                    assert 'mensaje' in response.result
+                    assert response.result.mensaje == message
+
+
         with context('list of pending files'):
             with it('must be performed as expected'):
                 with spec_VCR.use_cassette('list.yaml'):

--- a/specs/client_spec.py
+++ b/specs/client_spec.py
@@ -72,10 +72,24 @@ with description('A new'):
                     response = self.client.fetch(cups=the_cups, file_type=the_type)
                     
                     assert response
-                    print (response)
                     
                     """
                     print (response)
                     for element in response.result:
                         print (element.nombre, element.estado, element.tipoFichero, element.uriDescargas)
                     """
+
+
+        with context('download of a file'):
+            with it('must be performed as expected'):
+                with spec_VCR.use_cassette('download.yaml'):
+                    response = self.client.list()
+                    assert response
+
+                    # Extract the filename from the URL
+                    filename = str(response['result'][0].uriDescargas).split("/")[-1]
+
+                    # Ask the API to download it
+                    response = self.client.download(filename=filename)
+                    print (response)
+                    assert response

--- a/specs/client_spec.py
+++ b/specs/client_spec.py
@@ -22,6 +22,9 @@ config = {
 expected = {
 }
 
+LIST_OF_CUPS = ["ES0021000000228141PR", "ES0021000002097098PR", "ES0021000003589973DS"]
+LIST_OF_FILE_TYPES = ["SIPS2_PS_ELECTRICIDAD", "SIPS2_CONSUMOS_ELECTRICIDAD", "SIPS2_PS_GAS", "SIPS2_CONSUMOS_GAS"]
+
 with description('A new'):
     with before.each:
         with spec_VCR.use_cassette('init.yaml'):
@@ -41,7 +44,26 @@ with description('A new'):
                     response = self.client.list()
                     
                     assert response
-
+                    
+                    """
                     print (response)
                     for element in response.result:
                         print (element.nombre, element.estado, element.tipoFichero, element.uriDescargas)
+                    """
+
+        with context('reach files for some CUPS'):
+            with it('must be performed as expected'):
+                with spec_VCR.use_cassette('fetch.yaml'):
+                    the_cups = [ LIST_OF_CUPS[0] ]
+                    the_type = LIST_OF_FILE_TYPES[1]
+                    
+                    response = self.client.fetch(cups=the_cups, file_type=the_type)
+                    
+                    assert response
+                    print (response)
+                    
+                    """
+                    print (response)
+                    for element in response.result:
+                        print (element.nombre, element.estado, element.tipoFichero, element.uriDescargas)
+                    """

--- a/specs/client_spec.py
+++ b/specs/client_spec.py
@@ -10,11 +10,13 @@ from cnmc import Client
 fixtures_path = 'specs/fixtures/cnmc/'
 
 spec_VCR = vcr.VCR(
-    record_mode='new_episodes',
+    record_mode='all',
     cassette_library_dir=fixtures_path
 )
 
 config = {
+#    'key': 'the_key',
+#    'secret': 'the_secret',
 }
 
 expected = {
@@ -22,13 +24,17 @@ expected = {
 
 with description('A new'):
     with before.each:
-        self.config = config
-        self.expected = expected
-        self.client = Client(**config)
+        with spec_VCR.use_cassette('init.yaml'):
+            self.config = config
+            self.expected = expected
+            self.client = Client(**config)
 
     with context('CNMC client'):
         with context('initialization'):
             with it('must be performed as expected'):
                 with spec_VCR.use_cassette('init.yaml'):
-                    pass
+                    response = self.client.list()
+                    print (response)
 
+                    for element in response['result']:
+                        print (element.keys())

--- a/specs/cncm_spec.py
+++ b/specs/cncm_spec.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import)
+import vcr
+
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+from cnmc import CNMC_API
+
+fixtures_path = 'specs/fixtures/cnmc/'
+
+spec_VCR = vcr.VCR(
+    record_mode='all',
+    cassette_library_dir=fixtures_path
+)
+
+config = {
+    'key': 'the_key',
+    'secret': 'the_secret',
+}
+
+expected = {
+}
+
+with description('A new'):
+    with before.each:
+        with spec_VCR.use_cassette('init.yaml'):
+            self.config = config
+            self.expected = expected
+            self.client = CNMC_API(**config)
+
+    with context('CNMC API'):
+        with context('initialization'):
+            with it('must be performed as expected'):
+                with spec_VCR.use_cassette('init.yaml'):
+                    result = self.client.test("ROLF")
+                    print (result)

--- a/specs/cncm_spec.py
+++ b/specs/cncm_spec.py
@@ -33,5 +33,5 @@ with description('A new'):
         with context('initialization'):
             with it('must be performed as expected'):
                 with spec_VCR.use_cassette('init.yaml'):
-                    result = self.client.test("ROLF")
+                    result = self.client.test(message="ROLF")
                     print (result)


### PR DESCRIPTION
# Release 0.1.0

It provides the main skeleton of the CNMC client library

Concretely:
- `cnmc/client.py` contains all abstract methods desired to simplify customer interaction with the ending CNMC API.
- `cnmc/cnmc.py` integrates the OAuth session initialization with the ending backend and defines how to interact using the basic HTTP actions GET and POST.
- `cnmc/models.py` isolates all the Models and Schemas used to validate and deserialize API responses.

All functionalities are tested with a basic scope, see `specs/` files. WIP to extend it and integrate some CI provider.

Detail of the library is defined at README.md

New requirements
- Marshmallow
- Munch

### Fixed issues
- Fix #1 Provide MVP of the CNCM client
- Fix #3 Validate API responses and deserialize it to objects

