### PR TITLE
Take version from init file on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,17 @@
 # -*- coding: utf-8 -*-
+import io
+import re
 from setuptools import setup, find_packages
-import cnmc_client
+
+with io.open('cnmc_client/__init__.py', 'rt', encoding='utf8') as f:
+    version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 INSTALL_REQUIRES = ['Authlib', 'Munch', 'Marshmallow']
 
 setup(
     name='CNMC Client',
     description='Python client desired to interact with the CNMC API',
-    version=cnmc_client.__version__,
+    version=version,
     url='https://www.gisce.net',
     author='Xavi Torelló',
     author_email='xtorello@gisce.net',


### PR DESCRIPTION
When installing from clean virtualenv when setup import `import cnmc_client` this try to load on this [line]( https://github.com/gisce/cnmc_client/blob/master/cnmc_client/cnmc.py#L3) import authlib before it was installed

```
from authlib.client import OAuth1Session
import logging
from io import BytesIO
``` 

this change is inspired on Flask how to take version number.
https://github.com/pallets/flask/blob/master/setup.py#L12

 