### PR TITLE
Avoid error when len(cups) is multiple of chunk size

### DIFF
--- a/cnmc_client/client.py
+++ b/cnmc_client/client.py
@@ -107,6 +107,9 @@ class Client(object):
         number_of_cups = len(cups)
         chunk_indexes = [x*CUPS_CHUNK_SIZE for x in range(0, number_of_cups/CUPS_CHUNK_SIZE + 1)]
 
+        if chunk_indexes[len(chunk_indexes) - 1:] == [len(cups)]:
+            chunk_indexes = chunk_indexes[:-1]
+
         for chunk_block in chunk_indexes:
             time.sleep(wait)
 


### PR DESCRIPTION
When len(cups) is multiple of chunk size last chunk is empty and makes this assert to fail https://github.com/gisce/cnmc_client/blob/devel/cnmc_client/client.py#L142